### PR TITLE
feat: support js modules as config files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,9 @@ export async function readConfig<T>(configFile: string): Promise<ReadConfigResul
   if (configFile.endsWith(".json5") || configFile.endsWith(".json")) {
     result = require("json5").parse(data)
   }
+  else if (configFile.endsWith(".js")) {
+    result = require(configFile)
+  }
   else if (configFile.endsWith(".toml")) {
     result = require("toml").parse(data)
   }


### PR DESCRIPTION
## Context
I have been trying to get cross-platform env vars / dynamic config for `electron-builder`. Especially useful for local development.

I was not able to make `electron-builder.env`, nor [config files macros](https://www.electron.build/file-patterns#file-macros) work.

## Solution
Nodejs has already everything we need. Simply require a config as a script and let people handle how variables are passed. Electron-builder shouldn't concern itself on how to build and require config variables. I have traced the config load to this module, hence the PR here, but we can do this elsewhere.

As a result it took 5 sec to get the expected config, working cross platform, with the "usual" node module way with `dotenv`.

_electron-builder.config.js_
```
require('dotenv').config()

module.exports = {
  'productName': 'Kaiku',
  'publish': {
    'provider': 's3',
    'bucket': process.env.S3_BUCKET,
    'endpoint': process.env.S3_ENDPOINT
  },
```

_.env_
```
S3_BUCKET=test-electron-update
S3_ENDPOINT=http://192.168.0.101:9000
```