### PR TITLE
feat: Add `.mjs` file support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,5 +7,6 @@ Read configuration file in various formats:
 * json
 * js
 * cjs
+* mjs
 * toml (if installed, `yarn add toml`).
 * ts

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,11 +17,8 @@ async function readConfig<T>(configFile: string, request: ReadConfigRequest): Pr
   if (configFile.endsWith(".json5") || configFile.endsWith(".json")) {
     result = require("json5").parse(data)
   }
-  else if (configFile.endsWith(".mjs")) {
-    result = (await import(pathToFileURL(configFile))).default
-  }
-  else if (configFile.endsWith(".js") || configFile.endsWith(".cjs")) {
-    result = require(configFile)
+  else if (configFile.endsWith(".js") || configFile.endsWith(".cjs") || configFile.endsWith(".mjs")) {
+    result = configFile.endsWith(".mjs") ? await import(pathToFileURL(configFile)) : require(configFile)
     if (result.default != null) {
       result = result.default
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import * as path from "path"
 import { Lazy } from "lazy-val"
 import { parse as parseEnv } from "dotenv"
 import { loadTsConfig } from "config-file-ts"
+import { pathToFileURL } from 'url';
 
 export interface ReadConfigResult<T> {
   readonly result: T
@@ -15,6 +16,9 @@ async function readConfig<T>(configFile: string, request: ReadConfigRequest): Pr
   let result
   if (configFile.endsWith(".json5") || configFile.endsWith(".json")) {
     result = require("json5").parse(data)
+  }
+  else if (configFile.endsWith(".mjs")) {
+    result = (await import(pathToFileURL(configFile))).default
   }
   else if (configFile.endsWith(".js") || configFile.endsWith(".cjs")) {
     result = require(configFile)
@@ -44,7 +48,7 @@ async function readConfig<T>(configFile: string, request: ReadConfigRequest): Pr
 
 export async function findAndReadConfig<T>(request: ReadConfigRequest): Promise<ReadConfigResult<T> | null> {
   const prefix = request.configFilename
-  for (const configFile of [`${prefix}.yml`, `${prefix}.yaml`, `${prefix}.json`, `${prefix}.json5`, `${prefix}.toml`, `${prefix}.js`, `${prefix}.cjs`, `${prefix}.ts`]) {
+  for (const configFile of [`${prefix}.yml`, `${prefix}.yaml`, `${prefix}.json`, `${prefix}.json5`, `${prefix}.toml`, `${prefix}.js`,  `${prefix}.mjs`, `${prefix}.cjs`, `${prefix}.ts`]) {
     const data = await orNullIfFileNotExist(readConfig<T>(path.join(request.projectDir, configFile), request))
     if (data != null) {
       return data

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,10 @@ async function readConfig<T>(configFile: string, request: ReadConfigRequest): Pr
     result = require("json5").parse(data)
   }
   else if (configFile.endsWith(".js") || configFile.endsWith(".cjs") || configFile.endsWith(".mjs")) {
-    result = configFile.endsWith(".mjs") ? await import(pathToFileURL(configFile).toString()) : require(configFile)
+    result = configFile.endsWith(".mjs")
+        ? await import(pathToFileURL(configFile).toString())
+        : require(configFile)
+
     if (result.default != null) {
       result = result.default
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function readConfig<T>(configFile: string, request: ReadConfigRequest): Pr
     result = require("json5").parse(data)
   }
   else if (configFile.endsWith(".js") || configFile.endsWith(".cjs") || configFile.endsWith(".mjs")) {
-    result = configFile.endsWith(".mjs") ? await import(pathToFileURL(configFile)) : require(configFile)
+    result = configFile.endsWith(".mjs") ? await import(pathToFileURL(configFile).toString()) : require(configFile)
     if (result.default != null) {
       result = result.default
     }


### PR DESCRIPTION
resolve #10

Added case for `.mjs` config. Used native [Dynamic import()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) to read and parse file content.

Notes: 
- Probably `loadTsConfig` can read regular ESM js files as well.
- Package requires "node": ">=12.0.0", but acording to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#browser_compatibility) Dynamic import() in node 12 still experimental and was released in v13.2.0
- Not covered case: if user package has `type: module` and config file has `.js` extention. 